### PR TITLE
[WIP] Add Dockerfile to generate the Nulecule index into an image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,8 @@ FROM vpavlin/atomicapp
 
 LABEL RUN="docker run --rm $IMAGE"
 
-RUN yum -y install git && \
-    cd /tmp && \
-    git clone https://github.com/vpavlin/nulecule-library && \
-    cd nulecule-library && \
-    atomicapp index generate . && \
-    mv gen_index.yaml /gen_index.yaml && \
-    rm -rf /tmp/nulecule-library && \
-    yum -y remove git && \
-    yum -y clean all 
+RUN cd /tmp && \
+    atomicapp index generate https://github.com/projectatomic/nulecule-library && \
+    mv gen_index.yaml /gen_index.yaml
 
 ENTRYPOINT echo "This image contains index information about Nulecule applications stored in nulecule-library"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM vpavlin/atomicapp
+
+LABEL RUN="docker run --rm $IMAGE"
+
+RUN yum -y install git && \
+    cd /tmp && \
+    git clone https://github.com/vpavlin/nulecule-library && \
+    cd nulecule-library && \
+    atomicapp index generate . && \
+    mv gen_index.yaml /gen_index.yaml && \
+    rm -rf /tmp/nulecule-library && \
+    yum -y remove git && \
+    yum -y clean all 
+
+ENTRYPOINT echo "This image contains index information about Nulecule applications stored in nulecule-library"


### PR DESCRIPTION
This PR adds Dockerfile to the root of `nulecule-library` repository. This Dockerfile uses new feature of Atomic App I am also proposing - generation of the Index. When an Automated Build is set up, this Dockerfile will result in an image containing metadata for all Nulecule apps/components residing in this repository.

Kudos to @dustymabe for the idea of shipping the Index in an image:)

You can see the example image on Docker Hub as `nulecule/index`

```
$ docker run --rm nulecule/index
This image contains index information about Nulecule applications stored in nulecule-library
```
