### PR TITLE
wordpress: fix invalid item in object

### DIFF
--- a/wordpress-centos7-atomicapp/artifacts/kubernetes/wordpress-service.yaml
+++ b/wordpress-centos7-atomicapp/artifacts/kubernetes/wordpress-service.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   ports:
     - port: 80
-      containerPort: 80
+      targetPort: 80
   selector:
     name: wordpress-frontend


### PR DESCRIPTION
containerPort is not valid in a service definition.
