### PR TITLE
update redis example

### DIFF
--- a/redis-centos7-atomicapp/README.md
+++ b/redis-centos7-atomicapp/README.md
@@ -64,7 +64,7 @@ With a kubernetes service, once its pods are in the "Running" state, you can use
 $ kubectl get service redis-master
 NAME           LABELS                   SELECTOR                 IP              PORT(S)
 redis-master   name=redis,role=master   name=redis,role=master   <IP Address>    <port>/TCP
-$ docker run --rm -it centos/redis redis-cli -h <IP Address> -p <port>
+$ docker run --rm -it --entrypoint=redis-cli centos/redis -h <IP Address> -p <port>
 <IP Address>:<port>> get key
 (nil)
 <IP Address>:<port>> set key value

--- a/redis-centos7-atomicapp/artifacts/docker/redis-slave_run
+++ b/redis-centos7-atomicapp/artifacts/docker/redis-slave_run
@@ -1,2 +1,2 @@
-docker run -d --name redis-slave -p ::$hostport --link redis-master:redis-master $image /etc/redis.conf --slaveof redis-master $hostport
+docker run -d --name redis-slave -p ::$hostport --link redis-master:redis-master $image /etc/redis.conf --slaveof redis-master $hostport --bind 0.0.0.0
 


### PR DESCRIPTION
- binds slave to 0.0.0.0 so you can connect to it
- small readme fix ( we switched to `centos/redis` image that has entrpoint set to `redis-server`)
