### PR TITLE
mariadb: fix service specification

### DIFF
--- a/mariadb-centos7-atomicapp/artifacts/kubernetes/mariadb-service.yaml
+++ b/mariadb-centos7-atomicapp/artifacts/kubernetes/mariadb-service.yaml
@@ -12,7 +12,7 @@ spec:
       nodePort: 0
   selector:
     name: mariadb
-  portalIP: None
+  clusterIP: None
   type: ClusterIP
   sessionAffinity: None
 status:


### PR DESCRIPTION
PortalIP is now deprecated in favor of ClusterIP.
