### PR TITLE
Fixes MongoDB atomicapp

### DIFF
--- a/mongodb-centos7-atomicapp/Dockerfile
+++ b/mongodb-centos7-atomicapp/Dockerfile
@@ -1,6 +1,9 @@
+# Original source by: Jeroen van Meeuwen <vanmeeuwen@kolabsys.com>
+# https://github.com/kanarip/kolab-atomicapp
+
 FROM projectatomic/atomicapp:0.4.3
 
-MAINTAINER Jeroen van Meeuwen <vanmeeuwen@kolabsys.com>
+MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 
 LABEL io.projectatomic.nulecule.specversion="0.0.2" \
       io.projectatomic.nulecule.providers="kubernetes,docker,openshift"

--- a/mongodb-centos7-atomicapp/Nulecule
+++ b/mongodb-centos7-atomicapp/Nulecule
@@ -43,7 +43,7 @@
                     "default": true
                 },
                 {
-                    "name": "mongodb_username",
+                    "name": "mongodb_user",
                     "description": "User name for MongoDB account to be created"
                 }
             ],

--- a/mongodb-centos7-atomicapp/README.md
+++ b/mongodb-centos7-atomicapp/README.md
@@ -1,10 +1,9 @@
 This is an atomic application based on the nulecule specification. Kubernetes and native docker are currently the only supported providers. You'll need to run this from a workstation that has the atomic command and kubectl client that can connect to a kubernetes master.
 
-It's a single container application based on the ``kolab/mongodb`` image.
+It's a single container application based on the ``centos/mongodb-26-centos7`` image.
 
 ### Option 1: Unattended
 
 Run the image. It will automatically use kubernetes as the orchestration provider.
 
-    $ [sudo] atomic run kolab/mongodb-centos7-atomicapp
-
+    $ [sudo] atomic run projectatomic/mongodb-centos7-atomicapp

--- a/mongodb-centos7-atomicapp/artifacts/docker/run-mongodb-atomicapp-pod
+++ b/mongodb-centos7-atomicapp/artifacts/docker/run-mongodb-atomicapp-pod
@@ -6,6 +6,6 @@ docker run -d \
     -e MONGODB_PASSWORD=$mongodb_password \
     -e MONGODB_QUIET=$mongodb_quiet \
     -e MONGODB_SMALLFILES=$mongodb_smallfiles \
-    -e MONGODB_USERNAME=$mongodb_username \
+    -e MONGODB_USER=$mongodb_user \
     -p 27017:27017 \
     $image

--- a/mongodb-centos7-atomicapp/artifacts/docker/run-mongodb-atomicapp-pod
+++ b/mongodb-centos7-atomicapp/artifacts/docker/run-mongodb-atomicapp-pod
@@ -1,11 +1,1 @@
-docker run -d \
-    --name mongodb-atomicapp-app \
-    -e MONGODB_ADMIN_PASSWORD=$mongodb_admin_password \
-    -e MONGODB_DATABASE=$mongodb_database \
-    -e MONGODB_NOPREALLOC=$mongodb_noprealloc \
-    -e MONGODB_PASSWORD=$mongodb_password \
-    -e MONGODB_QUIET=$mongodb_quiet \
-    -e MONGODB_SMALLFILES=$mongodb_smallfiles \
-    -e MONGODB_USER=$mongodb_user \
-    -p 27017:27017 \
-    $image
+docker run -d --name mongodb-atomicapp-app -e MONGODB_ADMIN_PASSWORD=$mongodb_admin_password -e MONGODB_DATABASE=$mongodb_database -e MONGODB_NOPREALLOC=$mongodb_noprealloc -e MONGODB_PASSWORD=$mongodb_password -e MONGODB_QUIET=$mongodb_quiet -e MONGODB_SMALLFILES=$mongodb_smallfiles -e MONGODB_USER=$mongodb_user -p 27017:27017 $image

--- a/mongodb-centos7-atomicapp/artifacts/kubernetes/pod.json
+++ b/mongodb-centos7-atomicapp/artifacts/kubernetes/pod.json
@@ -44,7 +44,7 @@
                     },
                     {
                         "name": "MONGODB_USER",
-                        "value": "$mongodb_username"
+                        "value": "$mongodb_user"
                     }
                 ]
             }


### PR DESCRIPTION
https://hub.docker.com/r/centos/mongodb-26-centos7/ caused us to switch from 
MONGODB_USERNAME to MONGODB_USER.

Atomic App does not interpret backslashes in the Docker artifact, those were
removed.
