### PR TITLE
Added default provider as kubernetes to all Nuleucle files

### DIFF
--- a/apache-centos7-atomicapp/Nulecule
+++ b/apache-centos7-atomicapp/Nulecule
@@ -6,6 +6,10 @@ metadata:
   name: Apache CentOS Atomic App
   appversion: 0.0.1
   description: Atomic app for deploying a really basic Apache HTTP server on CentOS
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph:
   - name: apache-centos7-atomicapp 
     params:

--- a/etherpad-centos7-atomicapp/Nulecule
+++ b/etherpad-centos7-atomicapp/Nulecule
@@ -7,6 +7,10 @@ metadata:
   appversion: 0.0.1
   description: Atomic app for deploying basic etherpad
 
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph: 
   - name: mariadb-centos7-atomicapp
     source: docker://projectatomic/mariadb-centos7-atomicapp

--- a/flask-redis-centos7-atomicapp/Nulecule
+++ b/flask-redis-centos7-atomicapp/Nulecule
@@ -6,6 +6,10 @@ metadata:
     name: Flask Redis Nulecule App
     appversion: 0.0.1
     description: Atomic app of a simple light weight Flask and Redis app. This app counts the number of page visits and stores the counter in Redis store
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph:
     - name: redis
       params:

--- a/gitlab-centos7-atomicapp/Nulecule
+++ b/gitlab-centos7-atomicapp/Nulecule
@@ -6,6 +6,10 @@ metadata:
   name: Gitlab App
   appversion: 1.2.0
   description: Gitlab.
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph:
   - name: redis
     params:

--- a/gocounter-scratch-atomicapp/Nulecule
+++ b/gocounter-scratch-atomicapp/Nulecule
@@ -6,6 +6,10 @@ metadata:
     name: gocounter
     appversion: 0.0.1
     description: Atomicapp of a golang based app that prints number of hits in past one minute
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph:
     - name: gocounter
       params:

--- a/guestbookgo-atomicapp/Nulecule
+++ b/guestbookgo-atomicapp/Nulecule
@@ -6,6 +6,10 @@ metadata:
   name: Guestbook-Go Atomic App
   appversion: 0.0.1
   description: Atomic app for deploying the k8s guestbook-go app
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph:
   - name: guestbookfront-app
     params:

--- a/helloapache/Nulecule
+++ b/helloapache/Nulecule
@@ -6,6 +6,10 @@ metadata:
   name: Hello Apache App
   appversion: 0.0.1
   description: Atomic app for deploying a really basic Apache HTTP server
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph:
   - name: helloapache-app
     params:

--- a/mariadb-centos7-atomicapp/Nulecule
+++ b/mariadb-centos7-atomicapp/Nulecule
@@ -6,6 +6,10 @@ metadata:
   name: MySQL Atomic App
   appversion: 1.0.0
   description: This is MySQL
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph:
   - name: mariadb-atomicapp
     params:

--- a/mariadb-fedora-atomicapp/Nulecule
+++ b/mariadb-fedora-atomicapp/Nulecule
@@ -8,6 +8,10 @@ metadata:
   license:
     name: GNU AFFERO GENERAL PUBLIC LICENSE, Version 3
     url: https://www.gnu.org/licenses/agpl-3.0.html
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph:
   - name: mariadb-app
     params:

--- a/mongodb-centos7-atomicapp/Nulecule
+++ b/mongodb-centos7-atomicapp/Nulecule
@@ -6,6 +6,13 @@
         "appversion": "1.0.0",
         "description": "This is MongoDB"
     },
+    "params": [
+        {
+            "name": "provider",
+            "description": "The specified default provider.",
+            "default": "kubernetes"
+        }
+    ],
     "graph": [
         {
             "name": "mongodb-atomicapp",

--- a/postgresql-centos7-atomicapp/Nulecule
+++ b/postgresql-centos7-atomicapp/Nulecule
@@ -6,6 +6,10 @@ metadata:
   name: PostgreSQL Atomic App
   appversion: 1.0.0
   description: This is PostgreSQL
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph:
   - name: postgresql-atomicapp
     params:

--- a/redis-centos7-atomicapp/Nulecule
+++ b/redis-centos7-atomicapp/Nulecule
@@ -6,6 +6,10 @@ metadata:
   name: Redis App
   appversion: 0.0.1
   description: Redis Atomic App
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph:
   - name: redismaster-app
     params:

--- a/skydns-atomicapp/Nulecule
+++ b/skydns-atomicapp/Nulecule
@@ -7,6 +7,10 @@ metadata:
   description: >
     This is a nulecule that will get you the container components you need
     to dev on nulecule apps
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph:
   - name: skydns
     params:

--- a/wordpress-centos7-atomicapp/Nulecule
+++ b/wordpress-centos7-atomicapp/Nulecule
@@ -6,6 +6,10 @@ metadata:
   name: Wordpress App
   appversion: 2.0.0
   description: Simple Wordpress atomic app. Uses remote mysql atomic app.
+params:
+    - name: provider
+      description: The specified default provider.
+      default: kubernetes
 graph:
   - name: mariadb-centos7-atomicapp
     source: docker://projectatomic/mariadb-centos7-atomicapp


### PR DESCRIPTION
Before there was no section for the default providers in the Nulecule files. Either user had to specify provider via command line or via answers file. Now user can simply goto Nulecule file and change the provider of choice.

Fixes issue #65
