### PR TITLE
http-server should be specified under guestbookgo

### DIFF
--- a/guestbookgo-atomicapp/artifacts/kubernetes/guestbook-service.json
+++ b/guestbookgo-atomicapp/artifacts/kubernetes/guestbook-service.json
@@ -11,7 +11,7 @@
       "ports": [
          {
            "port":3000,
-           "targetPort":3000
+           "targetPort": "http-server"
          }
       ],
       "selector":{


### PR DESCRIPTION
Should conform to how k8s does it officially:
https://github.com/kubernetes/kubernetes/blob/master/examples/guestbook-go/guestbook-service.json
