### PR TITLE
Add the location metadata as well as clean up the Nulecule file

### DIFF
--- a/apache-centos7-atomicapp/Nulecule
+++ b/apache-centos7-atomicapp/Nulecule
@@ -5,11 +5,14 @@ id: apache-centos7-atomicapp
 metadata:
   name: Apache CentOS Atomic App
   appversion: 0.0.1
+  location: docker.io/projectatomic/apache-centos7-atomicapp
   description: Atomic app for deploying a really basic Apache HTTP server on CentOS
+
 params:
     - name: provider
       description: The specified default provider.
       default: kubernetes
+
 graph:
   - name: apache-centos7-atomicapp 
     params:

--- a/etherpad-centos7-atomicapp/Nulecule
+++ b/etherpad-centos7-atomicapp/Nulecule
@@ -6,6 +6,7 @@ metadata:
   name: etherpad-app
   appversion: 0.0.1
   description: Atomic app for deploying basic etherpad
+  location: docker.io/projectatomic/etherpad-centos7-atomicapp
 
 params:
     - name: provider

--- a/flask-redis-centos7-atomicapp/Nulecule
+++ b/flask-redis-centos7-atomicapp/Nulecule
@@ -6,10 +6,13 @@ metadata:
     name: Flask Redis Nulecule App
     appversion: 0.0.1
     description: Atomic app of a simple light weight Flask and Redis app. This app counts the number of page visits and stores the counter in Redis store
+    location: docker.io/projectatomic/flask-redis-centos7-atomicapp
+
 params:
     - name: provider
       description: The specified default provider.
       default: kubernetes
+
 graph:
     - name: redis
       params:

--- a/gitlab-centos7-atomicapp/Nulecule
+++ b/gitlab-centos7-atomicapp/Nulecule
@@ -6,10 +6,13 @@ metadata:
   name: Gitlab App
   appversion: 1.2.0
   description: Gitlab.
+  location: docker.io/projectatomic/gitlab-centos7-atomicapp
+
 params:
     - name: provider
       description: The specified default provider.
       default: kubernetes
+
 graph:
   - name: redis
     params:

--- a/gocounter-scratch-atomicapp/Nulecule
+++ b/gocounter-scratch-atomicapp/Nulecule
@@ -6,10 +6,13 @@ metadata:
     name: gocounter
     appversion: 0.0.1
     description: Atomicapp of a golang based app that prints number of hits in past one minute
+    location: docker.io/projectatomic/gocounter-scratch-atomicapp
+
 params:
     - name: provider
       description: The specified default provider.
       default: kubernetes
+
 graph:
     - name: gocounter
       params:

--- a/guestbookgo-atomicapp/Nulecule
+++ b/guestbookgo-atomicapp/Nulecule
@@ -6,10 +6,13 @@ metadata:
   name: Guestbook-Go Atomic App
   appversion: 0.0.1
   description: Atomic app for deploying the k8s guestbook-go app
+  location: docker.io/projectatomic/guestbookgo-atomicapp
+
 params:
     - name: provider
       description: The specified default provider.
       default: kubernetes
+
 graph:
   - name: guestbookfront-app
     params:

--- a/helloapache/Nulecule
+++ b/helloapache/Nulecule
@@ -6,10 +6,13 @@ metadata:
   name: Hello Apache App
   appversion: 0.0.1
   description: Atomic app for deploying a really basic Apache HTTP server
+  location: docker.io/projectatomic/helloapache
+
 params:
     - name: provider
       description: The specified default provider.
       default: kubernetes
+
 graph:
   - name: helloapache-app
     params:

--- a/mariadb-centos7-atomicapp/Nulecule
+++ b/mariadb-centos7-atomicapp/Nulecule
@@ -3,13 +3,16 @@ specversion: 0.0.2
 id: mariadb-atomicapp
 
 metadata:
-  name: MySQL Atomic App
+  name: MariaDB Atomic App
   appversion: 1.0.0
-  description: This is MySQL
+  description: This is a MariaDB database
+  location: docker.io/projectatomic/mariadb-centos7-atomicapp
+
 params:
     - name: provider
       description: The specified default provider.
       default: kubernetes
+
 graph:
   - name: mariadb-atomicapp
     params:

--- a/mariadb-fedora-atomicapp/Nulecule
+++ b/mariadb-fedora-atomicapp/Nulecule
@@ -1,6 +1,7 @@
 ---
 specversion: 0.0.2
 id: mariadb-app
+
 metadata:
   name: MariaDB App
   appversion: 0.0.1
@@ -8,10 +9,13 @@ metadata:
   license:
     name: GNU AFFERO GENERAL PUBLIC LICENSE, Version 3
     url: https://www.gnu.org/licenses/agpl-3.0.html
+  location: docker.io/projectatomic/mariadb-fedora-atomicapp
+
 params:
     - name: provider
       description: The specified default provider.
       default: kubernetes
+
 graph:
   - name: mariadb-app
     params:

--- a/mongodb-centos7-atomicapp/Nulecule
+++ b/mongodb-centos7-atomicapp/Nulecule
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "MongoDB Server",
         "appversion": "1.0.0",
-        "description": "This is MongoDB"
+        "description": "This is MongoDB",
+        "location": "docker.io/projectatomic/mongodb-centos7-atomicapp"
     },
     "params": [
         {

--- a/postgresql-centos7-atomicapp/Nulecule
+++ b/postgresql-centos7-atomicapp/Nulecule
@@ -6,10 +6,13 @@ metadata:
   name: PostgreSQL Atomic App
   appversion: 1.0.0
   description: This is PostgreSQL
+  location: docker.io/projectatomic/postgresql-centos7-atomicapp
+
 params:
     - name: provider
       description: The specified default provider.
       default: kubernetes
+
 graph:
   - name: postgresql-atomicapp
     params:

--- a/redis-centos7-atomicapp/Nulecule
+++ b/redis-centos7-atomicapp/Nulecule
@@ -6,10 +6,13 @@ metadata:
   name: Redis App
   appversion: 0.0.1
   description: Redis Atomic App
+  location: docker.io/projectatomic/redis-centos7-atomicapp
+
 params:
     - name: provider
       description: The specified default provider.
       default: kubernetes
+
 graph:
   - name: redismaster-app
     params:

--- a/skydns-atomicapp/Nulecule
+++ b/skydns-atomicapp/Nulecule
@@ -1,16 +1,20 @@
 ---
 specversion: 0.0.2
 id: skydns-atomicapp
+
 metadata:
   name: SkyDNS
   appversion: 2015-10-21-001
   description: >
     This is a nulecule that will get you the container components you need
     to dev on nulecule apps
+  location: docker.io/projectatomic/skydns-atomicapp
+
 params:
     - name: provider
       description: The specified default provider.
       default: kubernetes
+
 graph:
   - name: skydns
     params:

--- a/wordpress-centos7-atomicapp/Nulecule
+++ b/wordpress-centos7-atomicapp/Nulecule
@@ -6,10 +6,13 @@ metadata:
   name: Wordpress App
   appversion: 2.0.0
   description: Simple Wordpress atomic app. Uses remote mysql atomic app.
+  location: docker.io/projectatomic/wordpress-centos7-atomicapp
+
 params:
     - name: provider
       description: The specified default provider.
       default: kubernetes
+
 graph:
   - name: mariadb-centos7-atomicapp
     source: docker://projectatomic/mariadb-centos7-atomicapp


### PR DESCRIPTION
This commit adds the 'location' metadata to each Nulecule file. Using
the FULL URL (due to different locations / docker container providers)

This is in-line to the future addition of the `atomicapp index` command
which will list supported and well documented Atomic App example
applications.

This commit also cleans up some changes to the Nulecule files in order
to make the formatting a bit better.

ping @kadel @rtnpro @dustmabe @vpavlin (if you're there :) + keeping you informed on this process)
