### PR TITLE
mariadb-centos: Change kubernetes service definition.

### DIFF
--- a/mariadb-centos7-atomicapp/artifacts/kubernetes/mariadb-service.yaml
+++ b/mariadb-centos7-atomicapp/artifacts/kubernetes/mariadb-service.yaml
@@ -1,19 +1,11 @@
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: mariadb
   labels:
     name: mariadb
 spec:
   ports:
-    - protocol: TCP
-      port: 3306
-      targetPort: 3306
-      nodePort: 0
+    - port: 3306
   selector:
     name: mariadb
-  clusterIP: None
-  type: ClusterIP
-  sessionAffinity: None
-status:
-  loadBalancer: {}


### PR DESCRIPTION
Gets rid of unneeded things. Fixes #93 so that ther services
will now have a clusterIP.
