### PR TITLE
Fix issue with deploying to k8s with etherpad

### DIFF
--- a/etherpad-centos7-atomicapp/artifacts/kubernetes/etherpad-rc.yaml
+++ b/etherpad-centos7-atomicapp/artifacts/kubernetes/etherpad-rc.yaml
@@ -28,6 +28,6 @@ spec:
             - name: DB_PASS
               value: $db_pass
             - name: DB_PORT
-              value: $db_port
+              value: '$db_port'
             - name: DB_USER
               value: $db_user

--- a/etherpad-centos7-atomicapp/artifacts/openshift/etherpad-rc.yaml
+++ b/etherpad-centos7-atomicapp/artifacts/openshift/etherpad-rc.yaml
@@ -27,6 +27,6 @@ spec:
             - name: DB_PASS
               value: $db_pass
             - name: DB_PORT
-              value: $db_port
+              value: '$db_port'
             - name: DB_USER
               value: $db_user


### PR DESCRIPTION
We get this error when deploying to kubernetes with the etherpad:

```
ERROR  :: - cli/main.py :: Unable to complete request: Status: 400,
Error: {u'status': u'Failure', u'kind': u'Status', u'code': 400,
u'apiVersion': u'v1', u'reason': u'BadRequest', u'message':
u'ReplicationController in version "v1" cannot be handled as a
ReplicationController: [pos 297]: json: expect char \'"\' but got char
\'3\'', u'metadata': {}}
```

This PR adds the quotes back and fixes the issue when deploying.
