### PR TITLE
fix postgresql and add pvc for db storage

### DIFF
--- a/postgresql-centos7-atomicapp/Nulecule
+++ b/postgresql-centos7-atomicapp/Nulecule
@@ -26,6 +26,7 @@ graph:
       kubernetes:
         - file://artifacts/kubernetes/postgresql-pod.yaml
         - file://artifacts/kubernetes/postgresql-service.yaml
+        - file://artifacts/openshift/volume.yaml
       openshift:
         - inherit:
           - kubernetes

--- a/postgresql-centos7-atomicapp/artifacts/kubernetes/postgresql-pod.yaml
+++ b/postgresql-centos7-atomicapp/artifacts/kubernetes/postgresql-pod.yaml
@@ -7,13 +7,20 @@ metadata:
 spec:
   containers:
     - name: postgresql
-      image: centos/postgresql
+      image: centos/postgresql-95-centos7
       env:
-        - name: DB_NAME
+        - name: POSTGRESQL_DATABASE
           value: $db_name
-        - name: DB_USER
+        - name: POSTGRESQL_USER
           value: $db_user
-        - name: DB_PASS
-          value: $db_pass
+        - name: POSTGRESQL_PASSWORD
+          value: $dp_pass
       ports:
         - containerPort: 5432
+      volumeMounts:
+        - name: postgresql-persistent-storage
+          mountPath: /var/lib/pgsql/data
+  volumes:
+    - name: postgresql-persistent-storage
+      persistentVolumeClaim:
+       claimName: postgresql-claim

--- a/postgresql-centos7-atomicapp/artifacts/kubernetes/volume.yaml
+++ b/postgresql-centos7-atomicapp/artifacts/kubernetes/volume.yaml
@@ -1,0 +1,10 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: postgresql-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
The centos/postgres image does not appear to be available anymore.
https://hub.docker.com/r/centos/postgresql/tags/
